### PR TITLE
Support all type files that clang-format can format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
     name: clang-format
     entry: clang-format
     language: python
-    'types_or': [c++, c, c#]
+    'types_or': [c, c++, java, javascript, json, objective-c, proto, c#]
     args: ["-style=file", "-i"]
     require_serial: false
     additional_dependencies: []


### PR DESCRIPTION
A tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.
https://clang.llvm.org/docs/ClangFormat.html