### PR TITLE
refactor: move -i into entry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - run: pip install pre-commit-mirror-maker
     - run: git config --global user.name 'Github Actions'
     - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-    - run: pre-commit-mirror . --language=python --package-name=clang-format --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --args=-style=file,-i
+    - run: pre-commit-mirror . --language=python --package-name=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --args=-style=file
     - run: |
         git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
When looking at prettier-mirror, I noticed that the entry field had the required options in it as well, like `--write`. Clang-format's equivalent of write is `-i`, and the hook would not do anything interesting without it, so maybe it should be set that way in this one too? One downside is that clang-format explicitly checks for multiple `-i`, so this will provide an error if anyone is already overriding args and including `-i`:

```
clang-format: for the -i option: may only occur zero or one times!
```

This would be a clear error on upgrading the pin if someone was already overriding this, and maybe it's simpler/nicer/more "normal" for pre-commit in the long run?

@asottile up to you.