### PR TITLE
Add git-clang-format hook for 

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: clang-format
     name: clang-format
-    description: ''
+    description: 'Format entire file using `clang-format --style=file -i`'
     entry: clang-format
     language: python
     'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto]
@@ -11,12 +11,11 @@
 
 -   id: git-clang-format
     name: git-clang-format
-    description: 
+    description: 'Format changed lines of changed files using `git-clang-format --style file`'
     entry: git-clang-format
     language: python
     'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto]
-    args: ["-style=file", "-i"]
+    args: ["--style", "file", "$PRE_COMMIT_FROM_REF", "--"]
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
-

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,15 @@
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
+
+-   id: git-clang-format
+    name: git-clang-format
+    description: 
+    entry: git-clang-format
+    language: python
+    'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto]
+    args: ["-style=file", "-i"]
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'
+


### PR DESCRIPTION
This would be a useful addition, allowing large projects to bring their codebase into compliance without large diffs.