### PR TITLE
Add git-clang-format hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,14 @@
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
+
+-   id: git-clang-format
+    name: git-clang-format
+    description: ''
+    entry: git-clang-format
+    language: python
+    'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto]
+    args: ["--style=file"]
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'


### PR DESCRIPTION
[git-clang-format][1] provides out-of-the box integration with git. It is part of LLVM.
The clang-format-wheel project [exports][2] the executable, therefore it can be used as a pre-commit hook.

[1]: https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/git-clang-format
[2]: https://github.com/ssciwr/clang-format-wheel/blob/14.0.5/clang_format/__init__.py#L28