### PR TITLE
Add clang-format-diff hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,13 @@
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
+-   id: clang-format-diff
+    name: Check diff with clang-format
+    description: ''
+    entry: git-clang-format -f
+    language: python
+    'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto]
+    args: ["--style=file"]
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'
+    require_serial: true


### PR DESCRIPTION
This hook will reformat only the diffs instead of the whole files.