### PR TITLE
Add *.textproto support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - run: pip install pre-commit-mirror-maker
     - run: git config --global user.name 'Github Actions'
     - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --args=-style=file
+    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --types-or 'textproto' --args=-style=file
     - run: |
         git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
This allows clang-format to format files of the format https://protobuf.dev/reference/protobuf/textformat-spec/.

It also requires a change to https://github.com/pre-commit/identify.