### PR TITLE
Add support for git-clang-format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,13 @@
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
+-   id: git-clang-format
+    name: git-clang-format
+    description: ''
+    entry: git-clang-format
+    language: python
+    'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto, textproto]
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'
+    


### PR DESCRIPTION
This hook will only check changed lines on commit, rather than the whole file.