### PR TITLE
remove JSON since the hook breaks ipynb files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - run: pip install pre-commit-mirror-maker
     - run: git config --global user.name 'Github Actions'
     - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --types-or 'textproto' --types-or 'metal' --args=-style=file
+    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'objective-c' --types-or 'proto' --types-or 'textproto' --types-or 'metal' --args=-style=file
     - run: |
         git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
Clang-format 19 breaks ipynb files. xref: https://github.com/llvm/llvm-project/issues/110727 I can't find a way to exclude a format in pre-commit-mirror, so I remove the JSON format directly to ensure the hook doesn't break any files with the default configuration.