### PR TITLE
feat: add hook to only format hunks (instead of the whole file)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,14 @@
     require_serial: false
     additional_dependencies: []
     minimum_pre_commit_version: '2.9.2'
+
+-   id: clang-format-diff
+    name: clang-format
+    description: 'format only the modified hunks in the git diff, not the entire file'
+    entry: "sh -c 'git diff -U0 --no-color --relative HEAD^ | clang-format-diff.py -p1 -i'"
+    language: python
+    'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto, textproto, metal]
+    args: ["-style=file"]
+    require_serial: false
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'

--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Add this to your `.pre-commit-config.yaml`:
     hooks:
     -   id: clang-format
 ```
+
+Use `clang-format-diff` to format only the modified portions of the code, rather than the entire changed files.
+
+```yaml
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    -   id: clang-format-diff
+```


### PR DESCRIPTION
add a hook that formats only the git hunks and not the entire file, which is useful to avoid noisy changes in code bases that don't conform fully to a format specification. This would offer an alternative [pre-commit-hooks](https://github.com/jlebar/pre-commit-hooks), which doesn't track the `clang-format` versions as well as `mirrors-clang-format` does.