### PR TITLE
Explicitly exclude jupyter files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
     entry: clang-format -i
     language: python
     'types_or': [c++, c, c#, cuda, java, javascript, json, objective-c, proto, textproto, metal]
+    exclude_types: [jupyter]
     args: ["-style=file"]
     require_serial: false
     additional_dependencies: []


### PR DESCRIPTION
Alternative solution to #33.

[identify](https://github.com/pre-commit/identify/blob/dc20df20bda102dc74ca8531465bfcd20a7f26bf/identify/extensions.py#L122) also considers `.ipynb` files as json, which is correct. But I am very sure nobody wants to run json formatting on jupyter files, hence why not exclude it by default.