### PR TITLE
Explicitly exclude jupyter files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - run: pip install pre-commit-mirror-maker
     - run: git config --global user.name 'Github Actions'
     - run: git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --types-or 'textproto' --types-or 'metal' --args=-style=file
+    - run: pre-commit-mirror . --language=python --package-name=clang-format --id=clang-format --entry='clang-format -i' --types-or c++ --types-or c --types-or 'c#' --types-or 'cuda' --types-or 'java' --types-or 'javascript' --types-or 'json' --types-or 'objective-c' --types-or 'proto' --types-or 'textproto' --types-or 'metal' --exclude-types 'jupyter' --args=-style=file
     - run: |
         git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         git push origin HEAD:refs/heads/main --tags


### PR DESCRIPTION
Alternative solution to https://github.com/pre-commit/mirrors-clang-format/pull/33.

[identify](https://github.com/pre-commit/identify/blob/dc20df20bda102dc74ca8531465bfcd20a7f26bf/identify/extensions.py#L122) also considers .ipynb files as json, which is correct. But I am very sure nobody wants to run json formatting on jupyter files, hence why not exclude it by default.